### PR TITLE
[OPS-1966] security updates

### DIFF
--- a/src/make/iasc.make
+++ b/src/make/iasc.make
@@ -83,7 +83,7 @@ projects[apachesolr_attachments][version] = 1.4
 projects[apachesolr_attachments][subdir] = iasc_contrib
 
 projects[title][type] = module
-projects[title][version] = 1.0-alpha7
+projects[title][version] = 1.0-alpha9
 projects[title][subdir] = iasc_contrib
 
 projects[nodequeue][type] = module
@@ -155,7 +155,7 @@ projects[jquery_expander][version] = 1.0
 projects[jquery_expander][subdir] = iasc_contrib
 
 projects[views_data_export][type] = module
-projects[views_data_export][version] = 3.0-beta9
+projects[views_data_export][version] = 3.1
 projects[views_data_export][subdir] = iasc_contrib
 
 libraries[responsive-imagemaps][download][type] = get

--- a/src/make/includes/drupal-org-core.make
+++ b/src/make/includes/drupal-org-core.make
@@ -5,7 +5,7 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.44
+projects[drupal][version] = 7.52
 
 ; ***** Patches from Panopoly *******
 ; Bug with image styles on database update
@@ -41,15 +41,14 @@ projects[drupal][patch][2199001] = https://www.drupal.org/files/issues/node_acce
 ; Fix javascript error with angular
 projects[drupal][patch][2492993] = https://www.drupal.org/files/issues/2492993-drupal-hash-1.patch
 
-; Fixes an issue where _registry_check_code() gets called early in the bootstrap process. Stills throws a warning but
-; keeps it from throwing a fatal.
-projects[drupal][patch][412808] = https://www.drupal.org/files/issues/drupal-registry_fix-412808-32.patch
-
 ; Fixes sticky headers are not calculating the column widths properly.
 projects[drupal][patch][2097081] = https://www.drupal.org/files/2097081-fix-sticky-header-column-width-7.x-6.patch
 
 ; Prevent Drupal from scanning node_module and bower_component directories in theme
 projects[drupal][patch][2329453] = https://www.drupal.org/files/issues/ignore_front_end_vendor-2329453-111.patch
+
+; Issues with "required, multiple" fields in forms.
+projects[drupal][patch][980144] = https://www.drupal.org/files/issues/d7-issues_with_required-980144-76.patch
 
 ; Image style previews don't show when using a private file system.
 projects[drupal][patch][1440312] = https://www.drupal.org/files/issues/drupal-image-styles-1440312-35.patch

--- a/src/make/includes/openatrium.make
+++ b/src/make/includes/openatrium.make
@@ -7,7 +7,7 @@ core = 7.x
 ; ******************** RELEASE *******************
 
 projects[oa_core][subdir] = contrib
-projects[oa_core][version] = 2.79
+projects[oa_core][version] = 2.81
 
 ; ************************************************
 ; ************* Open Atrium Builtin Apps *********
@@ -16,13 +16,13 @@ projects[oa_discussion][subdir] = apps
 projects[oa_discussion][version] = 2.41
 
 projects[oa_events][subdir] = apps
-projects[oa_events][version] = 2.41
+projects[oa_events][version] = 2.44
 
 projects[oa_wiki][subdir] = apps
 projects[oa_wiki][version] = 2.40
 
 projects[oa_worktracker][subdir] = apps
-projects[oa_worktracker][version] = 2.9
+projects[oa_worktracker][version] = 2.11
 
 ; ******** End Open Atrium Builtin Apps **********
 ; ************************************************
@@ -32,7 +32,7 @@ projects[oa_worktracker][version] = 2.9
 ; ************* Open Atrium Core Addon Apps ******
 ; (Local optional apps that included by default)
 
-projects[oa_admin][version] = 2.2
+projects[oa_admin][version] = 2.3
 projects[oa_admin][subdir] = apps
 
 projects[oa_analytics][version] = 2.3
@@ -41,16 +41,16 @@ projects[oa_analytics][subdir] = apps
 projects[oa_appearance][version] = 2.7
 projects[oa_appearance][subdir] = apps
 
-projects[oa_archive][version] = 2.4
+projects[oa_archive][version] = 2.5
 projects[oa_archive][subdir] = apps
 
-projects[oa_brand][version] = 2.4
+projects[oa_brand][version] = 2.5
 projects[oa_brand][subdir] = apps
 
-projects[oa_clone][version] = 2.9
+projects[oa_clone][version] = 2.11
 projects[oa_clone][subdir] = apps
 
-projects[oa_comment][version] = 2.10
+projects[oa_comment][version] = 2.11
 projects[oa_comment][subdir] = apps
 
 projects[oa_contextual_tabs][version] = 2.33
@@ -68,13 +68,13 @@ projects[oa_export][subdir] = apps
 projects[oa_events_import][subdir] = apps
 projects[oa_events_import][version] = 2.27
 
-projects[oa_favorites][version] = 2.4
+projects[oa_favorites][version] = 2.5
 projects[oa_favorites][subdir] = apps
 
 projects[oa_files][version] = 2.18
 projects[oa_files][subdir] = apps
 
-projects[oa_home][version] = 2.4
+projects[oa_home][version] = 2.5
 projects[oa_home][subdir] = apps
 
 projects[oa_htmlmail][version] = 2.1
@@ -93,33 +93,33 @@ projects[oa_messages_digest][version] = 2.1
 projects[oa_messages_digest][subdir] = apps
 
 projects[oa_notifications][subdir] = apps
-projects[oa_notifications][version] = 2.30
+projects[oa_notifications][version] = 2.32
 
 projects[oa_project][version] = 2.2
 projects[oa_project][subdir] = apps
 
-projects[oa_related][version] = 2.10
+projects[oa_related][version] = 2.12
 projects[oa_related][subdir] = apps
 
 projects[oa_sandbox][version] = 2.2
 projects[oa_sandbox][subdir] = apps
 
-projects[oa_search][version] = 2.8
+projects[oa_search][version] = 2.9
 projects[oa_search][subdir] = apps
 
 projects[oa_site_layout][version] = 2.2
 projects[oa_site_layout][subdir] = apps
 
-projects[oa_sitemap][version] = 2.11
+projects[oa_sitemap][version] = 2.12
 projects[oa_sitemap][subdir] = apps
 
 projects[oa_styles][version] = 2.1
 projects[oa_styles][subdir] = apps
 
-projects[oa_subspaces][version] = 2.36
+projects[oa_subspaces][version] = 2.37
 projects[oa_subspaces][subdir] = apps
 
-projects[oa_toolbar][version] = 2.13
+projects[oa_toolbar][version] = 2.14
 projects[oa_toolbar][subdir] = apps
 
 projects[oa_tour][version] = 2.5
@@ -139,10 +139,10 @@ projects[oa_wizard][subdir] = apps
 ; ************** Open Atrium Themes **************
 
 projects[oa_basetheme][type] = theme
-projects[oa_basetheme][version] = 2.3
+projects[oa_basetheme][version] = 2.4
 
 projects[oa_theme][type] = theme
-projects[oa_theme][version] = 2.3
+projects[oa_theme][version] = 2.4
 
 projects[oa_radix][type] = theme
 projects[oa_radix][version] = 3.25
@@ -159,7 +159,7 @@ projects[oa_radix][version] = 3.25
 ; so we can patch or update certain projects fetched by Panopoly's makefiles.
 ; NOTE: If you are running Drush 6, this section should be placed at the TOP
 
-projects[panopoly_core][version] = 1.40
+projects[panopoly_core][version] = 1.41
 projects[panopoly_core][subdir] = panopoly
 projects[panopoly_core][patch][2477347] = https://www.drupal.org/files/issues/2477347-panopoly_core-views-4.patch
 projects[panopoly_core][patch][2477363] = https://www.drupal.org/files/issues/2477363-panopoly_core-ctools-17.patch
@@ -168,38 +168,37 @@ projects[panopoly_core][patch][2477375] = https://www.drupal.org/files/issues/24
 projects[panopoly_core][patch][2477379] = https://www.drupal.org/files/issues/2477379-panopoly_core-token-1.patch
 projects[panopoly_core][patch][2592821] = https://www.drupal.org/files/issues/2592821-panopoly_core-apps-2.patch
 
-projects[panopoly_images][version] = 1.40
+projects[panopoly_images][version] = 1.41
 projects[panopoly_images][subdir] = panopoly
 projects[panopoly_images][patch][2521968] = https://www.drupal.org/files/issues/panopoly_images-manualcrop_is_showing_for_videos-2521968-1.patch
 
-projects[panopoly_theme][version] = 1.40
+projects[panopoly_theme][version] = 1.41
 projects[panopoly_theme][subdir] = panopoly
 projects[panopoly_theme][patch][2656920] = https://www.drupal.org/files/issues/2656920-panopoly-theme-radix-layouts-4.patch
 
-projects[panopoly_magic][version] = 1.40
+projects[panopoly_magic][version] = 1.41
 projects[panopoly_magic][subdir] = panopoly
 projects[panopoly_magic][patch][2611876] = https://www.drupal.org/files/issues/panopoly_magic-add_descriptions_to-2611876-2.patch
 
-projects[panopoly_widgets][version] = 1.40
+projects[panopoly_widgets][version] = 1.41
 projects[panopoly_widgets][subdir] = panopoly
 projects[panopoly_widgets][patch][2473495] = https://www.drupal.org/files/issues/2473495-panopoly_widgets-media-14.patch
 projects[panopoly_widgets][patch][2477397] = https://www.drupal.org/files/issues/2477397-panopoly_widgets-file_entity-2.patch
 
-projects[panopoly_admin][version] = 1.40
+projects[panopoly_admin][version] = 1.41
 projects[panopoly_admin][subdir] = panopoly
 
-projects[panopoly_users][version] = 1.40
+projects[panopoly_users][version] = 1.41
 projects[panopoly_users][subdir] = panopoly
 
-projects[panopoly_pages][version] = 1.40
+projects[panopoly_pages][version] = 1.41
 projects[panopoly_pages][subdir] = panopoly
 
-projects[panopoly_wysiwyg][version] = 1.40
+projects[panopoly_wysiwyg][version] = 1.41
 projects[panopoly_wysiwyg][subdir] = panopoly
 
-projects[panopoly_search][version] = 1.40
+projects[panopoly_search][version] = 1.41
 projects[panopoly_search][subdir] = panopoly
-projects[panopoly_search][patch][2790595] = https://www.drupal.org/files/issues/solrphpclient_cannot_be-2790595-10.patch
 
 ; ***************** End Panopoly *****************
 ; ************************************************
@@ -224,4 +223,3 @@ projects[oa_responsive_regions][subdir] = contrib
 
 ; *********** End Open Atrium Contrib ************
 ; ************************************************
-


### PR DESCRIPTION
Doe not include the latest JS drag fix for Drupal 7.53 or the non-security fixes for 7.54.