### PR TITLE
[OPS-2636] Bump the IASC Makefiles to the latest OpenAtrium ones.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_script:
   - phpenv rehash
 
 script:
-  - ./vendor/bin/phpcs --standard=phpcs.xml --report=full
-  - ./vendor/bin/phpmd src/modules text phpmd.xml
+  - bin/phpcs --standard=phpcs.xml --report=full
+  - bin/phpmd src/modules text phpmd.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: php
+
+php:
+  - 5.6
+
+env:
+  global:
+     - DRUPAL_REPO='git://drupalcode.org/project/drupal.git'
+     - DRUPAL_VERSION='7.x'
+     - DRUSH_VERSION='7.*'
+     - PHPCS_VERSION='1.5.*@dev'
+     - CODER_VERSION='dev-7.x-2.x'
+
+before_script:
+  # Ensure we have the latest sources.
+  - sudo apt-get -y update
+
+  # Composer.
+  - sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
+  - source $HOME/.bashrc
+  - composer self-update
+
+  # Composering!
+  - composer install
+
+  # Ensure the PHP environment is ready.
+  - phpenv rehash
+
+script:
+  - ./vendor/bin/phpcs --standard=phpcs.xml --report=full
+  - ./vendor/bin/phpmd src/modules text phpmd.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # IASC CMS
 
+[![Master Branch Build Status](https://travis-ci.org/UN-OCHA/iasc_cms.svg?branch=master)](https://travis-ci.org/UN-OCHA/iasc_cms) [![Develop Branch Build Status](https://travis-ci.org/UN-OCHA/iasc_cms.svg?branch=develop)](https://travis-ci.org/UN-OCHA/iasc_cms)
+
 This is the IASC CMS src repository and build tools.
 
 You should install the [IASC CMS Environment](https://bitbucket.org/phase2tech/iasc_env) as part of the process of working with this repository.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="drupal">
+  <description>Default PHP CodeSniffer configuration for Drupal.</description>
+  <file>src/modules,src/themes</file>
+  <arg name="extensions" value="inc,info,install,module,php,profile,test,theme"/>
+  <!--Exclude generated party code.-->
+  <exclude-pattern>*.test</exclude-pattern>
+  <exclude-pattern>*.features.*</exclude-pattern>
+  <exclude-pattern>*.strongarm.inc</exclude-pattern>
+  <exclude-pattern>*.context.inc</exclude-pattern>
+  <exclude-pattern>*.views_default.inc</exclude-pattern>
+  <exclude-pattern>*.views_handler*</exclude-pattern>
+  <rule ref="vendor/drupal/coder/coder_sniffer/Drupal" />
+</ruleset>

--- a/src/make/includes/drupal-org-core.make
+++ b/src/make/includes/drupal-org-core.make
@@ -1,3 +1,5 @@
+; This is http://cgit.drupalcode.org/openatrium/plain/drupal-org-core.make
+
 api = 2
 core = 7.x
 
@@ -5,7 +7,7 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.52
+projects[drupal][version] = 7.54
 
 ; ***** Patches from Panopoly *******
 ; Bug with image styles on database update

--- a/src/make/includes/openatrium.make
+++ b/src/make/includes/openatrium.make
@@ -9,7 +9,7 @@ core = 7.x
 ; ******************** RELEASE *******************
 
 projects[oa_core][subdir] = contrib
-projects[oa_core][version] = 2.82
+projects[oa_core][version] = 2.85
 
 ; ************************************************
 ; ************* Open Atrium Builtin Apps *********
@@ -18,7 +18,7 @@ projects[oa_discussion][subdir] = apps
 projects[oa_discussion][version] = 2.41
 
 projects[oa_events][subdir] = apps
-projects[oa_events][version] = 2.45
+projects[oa_events][version] = 2.46
 
 projects[oa_wiki][subdir] = apps
 projects[oa_wiki][version] = 2.40
@@ -52,7 +52,7 @@ projects[oa_brand][subdir] = apps
 projects[oa_clone][version] = 2.12
 projects[oa_clone][subdir] = apps
 
-projects[oa_comment][version] = 2.13
+projects[oa_comment][version] = 2.15
 projects[oa_comment][subdir] = apps
 
 projects[oa_contextual_tabs][version] = 2.33
@@ -64,7 +64,7 @@ projects[oa_devel][subdir] = apps
 projects[oa_domains][version] = 2.3
 projects[oa_domains][subdir] = apps
 
-projects[oa_export][version] = 2.2
+projects[oa_export][version] = 2.3
 projects[oa_export][subdir] = apps
 
 projects[oa_events_import][subdir] = apps
@@ -89,7 +89,7 @@ projects[oa_markdown][version] = 2.2
 projects[oa_markdown][subdir] = apps
 
 projects[oa_media][subdir] = apps
-projects[oa_media][version] = 2.34
+projects[oa_media][version] = 2.35
 
 projects[oa_messages_digest][version] = 2.1
 projects[oa_messages_digest][subdir] = apps
@@ -106,7 +106,7 @@ projects[oa_related][subdir] = apps
 projects[oa_sandbox][version] = 2.2
 projects[oa_sandbox][subdir] = apps
 
-projects[oa_search][version] = 2.9
+projects[oa_search][version] = 2.10
 projects[oa_search][subdir] = apps
 
 projects[oa_site_layout][version] = 2.2
@@ -121,7 +121,7 @@ projects[oa_styles][subdir] = apps
 projects[oa_subspaces][version] = 2.37
 projects[oa_subspaces][subdir] = apps
 
-projects[oa_toolbar][version] = 2.14
+projects[oa_toolbar][version] = 2.15
 projects[oa_toolbar][subdir] = apps
 
 projects[oa_tour][version] = 2.5
@@ -164,7 +164,7 @@ projects[oa_radix][version] = 3.25
 projects[panopoly_core][version] = 1.43
 projects[panopoly_core][subdir] = panopoly
 projects[panopoly_core][patch][2477347] = https://www.drupal.org/files/issues/2477347-panopoly_core-views-4.patch
-projects[panopoly_core][patch][2477363] = https://www.drupal.org/files/issues/2477363-panopoly_core-ctools-20.patch
+projects[panopoly_core][patch][2477363] = https://www.drupal.org/files/issues/2477363-panopoly_core-ctools-21.patch
 projects[panopoly_core][patch][2477369] = https://www.drupal.org/files/issues/2477369-panopoly_core-entity-5.patch
 projects[panopoly_core][patch][2477375] = https://www.drupal.org/files/issues/2477375-panopoly_core-entityreference-1.patch
 projects[panopoly_core][patch][2477379] = https://www.drupal.org/files/issues/2477379-panopoly_core-token-1.patch
@@ -184,7 +184,7 @@ projects[panopoly_magic][patch][2611876] = https://www.drupal.org/files/issues/p
 
 projects[panopoly_widgets][version] = 1.43
 projects[panopoly_widgets][subdir] = panopoly
-projects[panopoly_widgets][patch][2473495] = https://www.drupal.org/files/issues/2473495-panopoly_widgets-media-16.patch
+projects[panopoly_widgets][patch][2473495] = https://www.drupal.org/files/issues/2473495-panopoly_widgets-media-19.patch
 projects[panopoly_widgets][patch][2477397] = https://www.drupal.org/files/issues/2477397-panopoly_widgets-file_entity-2.patch
 
 projects[panopoly_admin][version] = 1.43

--- a/src/make/includes/openatrium.make
+++ b/src/make/includes/openatrium.make
@@ -1,3 +1,5 @@
+; This is http://cgit.drupalcode.org/openatrium/tree/drupal-org.make
+
 api = 2
 core = 7.x
 
@@ -7,7 +9,7 @@ core = 7.x
 ; ******************** RELEASE *******************
 
 projects[oa_core][subdir] = contrib
-projects[oa_core][version] = 2.81
+projects[oa_core][version] = 2.82
 
 ; ************************************************
 ; ************* Open Atrium Builtin Apps *********
@@ -16,7 +18,7 @@ projects[oa_discussion][subdir] = apps
 projects[oa_discussion][version] = 2.41
 
 projects[oa_events][subdir] = apps
-projects[oa_events][version] = 2.44
+projects[oa_events][version] = 2.45
 
 projects[oa_wiki][subdir] = apps
 projects[oa_wiki][version] = 2.40
@@ -41,22 +43,22 @@ projects[oa_analytics][subdir] = apps
 projects[oa_appearance][version] = 2.7
 projects[oa_appearance][subdir] = apps
 
-projects[oa_archive][version] = 2.5
+projects[oa_archive][version] = 2.6
 projects[oa_archive][subdir] = apps
 
 projects[oa_brand][version] = 2.5
 projects[oa_brand][subdir] = apps
 
-projects[oa_clone][version] = 2.11
+projects[oa_clone][version] = 2.12
 projects[oa_clone][subdir] = apps
 
-projects[oa_comment][version] = 2.11
+projects[oa_comment][version] = 2.13
 projects[oa_comment][subdir] = apps
 
 projects[oa_contextual_tabs][version] = 2.33
 projects[oa_contextual_tabs][subdir] = apps
 
-projects[oa_devel][version] = 2.1
+projects[oa_devel][version] = 2.3
 projects[oa_devel][subdir] = apps
 
 projects[oa_domains][version] = 2.3
@@ -87,13 +89,13 @@ projects[oa_markdown][version] = 2.2
 projects[oa_markdown][subdir] = apps
 
 projects[oa_media][subdir] = apps
-projects[oa_media][version] = 2.33
+projects[oa_media][version] = 2.34
 
 projects[oa_messages_digest][version] = 2.1
 projects[oa_messages_digest][subdir] = apps
 
 projects[oa_notifications][subdir] = apps
-projects[oa_notifications][version] = 2.32
+projects[oa_notifications][version] = 2.34
 
 projects[oa_project][version] = 2.2
 projects[oa_project][subdir] = apps
@@ -159,45 +161,45 @@ projects[oa_radix][version] = 3.25
 ; so we can patch or update certain projects fetched by Panopoly's makefiles.
 ; NOTE: If you are running Drush 6, this section should be placed at the TOP
 
-projects[panopoly_core][version] = 1.41
+projects[panopoly_core][version] = 1.43
 projects[panopoly_core][subdir] = panopoly
 projects[panopoly_core][patch][2477347] = https://www.drupal.org/files/issues/2477347-panopoly_core-views-4.patch
-projects[panopoly_core][patch][2477363] = https://www.drupal.org/files/issues/2477363-panopoly_core-ctools-17.patch
+projects[panopoly_core][patch][2477363] = https://www.drupal.org/files/issues/2477363-panopoly_core-ctools-20.patch
 projects[panopoly_core][patch][2477369] = https://www.drupal.org/files/issues/2477369-panopoly_core-entity-5.patch
 projects[panopoly_core][patch][2477375] = https://www.drupal.org/files/issues/2477375-panopoly_core-entityreference-1.patch
 projects[panopoly_core][patch][2477379] = https://www.drupal.org/files/issues/2477379-panopoly_core-token-1.patch
-projects[panopoly_core][patch][2592821] = https://www.drupal.org/files/issues/2592821-panopoly_core-apps-2.patch
+projects[panopoly_core][patch][2592821] = https://www.drupal.org/files/issues/2592821-panopoly_core-apps-3.patch
 
-projects[panopoly_images][version] = 1.41
+projects[panopoly_images][version] = 1.43
 projects[panopoly_images][subdir] = panopoly
 projects[panopoly_images][patch][2521968] = https://www.drupal.org/files/issues/panopoly_images-manualcrop_is_showing_for_videos-2521968-1.patch
 
-projects[panopoly_theme][version] = 1.41
+projects[panopoly_theme][version] = 1.43
 projects[panopoly_theme][subdir] = panopoly
 projects[panopoly_theme][patch][2656920] = https://www.drupal.org/files/issues/2656920-panopoly-theme-radix-layouts-4.patch
 
-projects[panopoly_magic][version] = 1.41
+projects[panopoly_magic][version] = 1.43
 projects[panopoly_magic][subdir] = panopoly
 projects[panopoly_magic][patch][2611876] = https://www.drupal.org/files/issues/panopoly_magic-add_descriptions_to-2611876-2.patch
 
-projects[panopoly_widgets][version] = 1.41
+projects[panopoly_widgets][version] = 1.43
 projects[panopoly_widgets][subdir] = panopoly
-projects[panopoly_widgets][patch][2473495] = https://www.drupal.org/files/issues/2473495-panopoly_widgets-media-14.patch
+projects[panopoly_widgets][patch][2473495] = https://www.drupal.org/files/issues/2473495-panopoly_widgets-media-16.patch
 projects[panopoly_widgets][patch][2477397] = https://www.drupal.org/files/issues/2477397-panopoly_widgets-file_entity-2.patch
 
-projects[panopoly_admin][version] = 1.41
+projects[panopoly_admin][version] = 1.43
 projects[panopoly_admin][subdir] = panopoly
 
-projects[panopoly_users][version] = 1.41
+projects[panopoly_users][version] = 1.43
 projects[panopoly_users][subdir] = panopoly
 
-projects[panopoly_pages][version] = 1.41
+projects[panopoly_pages][version] = 1.43
 projects[panopoly_pages][subdir] = panopoly
 
-projects[panopoly_wysiwyg][version] = 1.41
+projects[panopoly_wysiwyg][version] = 1.43
 projects[panopoly_wysiwyg][subdir] = panopoly
 
-projects[panopoly_search][version] = 1.41
+projects[panopoly_search][version] = 1.43
 projects[panopoly_search][subdir] = panopoly
 
 ; ***************** End Panopoly *****************


### PR DESCRIPTION
* Pull in security updates.
* Add file comment to indicate which file from the OA project it is.