### PR TITLE
[OPS-3201] Simplify CSS/JS changes, so that we do not generate a broken asset array and cause notices all over the place.

### DIFF
--- a/src/themes/iasc/template.php
+++ b/src/themes/iasc/template.php
@@ -14,21 +14,12 @@ function iasc_css_alter(&$css) {
   // Radix now includes compiled stylesheets for demo purposes.
   // We remove these from our subtheme since they are already included
   // in compass_radix.
-  unset($css[$oa_radix_path . '/assets/stylesheets/oa_radix-style.css']);
-  unset($css[$oa_radix_path . '/assets/stylesheets/oa_radix-print.css']);
-
-  // Add a custom jQuery UI theme.
-  $css[$oa_radix_path . '/assets/vendor/jqueryui/jquery-ui-1.10.0.custom.css']['data'] = $oa_radix_path . '/assets/vendor/jqueryui/jquery-ui-1.10.0.custom.css';
-}
-
-/**
- * Implements hook_js_alter().
- */
-function iasc_js_alter(&$js) {
-  $oa_radix_path = drupal_get_path('theme', 'oa_radix');
-  // Add this script so that the jquery ui dialogs have the correct close button
-  // classes/etc.
-  $js[$oa_radix_path . '/assets/javascripts/script.js']['data'] = $oa_radix_path . '/assets/javascripts/script.js';
+  if (!empty($css[$oa_radix_path . '/assets/stylesheets/screen.css'])) {
+    unset($css[$oa_radix_path . '/assets/stylesheets/screen.css']);
+  }
+  if (!empty($css[$oa_radix_path . '/assets/stylesheets/print.css'])) {
+    unset($css[$oa_radix_path . '/assets/stylesheets/print.css']);
+  }
 }
 
 /**
@@ -95,6 +86,11 @@ function iasc_preprocess_html(&$vars) {
  * Implements template_preprocess_page().
  */
 function iasc_preprocess_page(&$variables) {
+
+  // Add a custom jQuery UI theme.
+  $oa_radix_path = drupal_get_path('theme', 'oa_radix');
+  drupal_add_css($oa_radix_path . '/assets/vendor/jqueryui/jquery-ui-1.10.0.custom.css');
+
   // Add copyright to theme.
   if ($copyright = theme_get_setting('copyright')) {
     $variables['copyright'] = check_markup($copyright['value'], $copyright['format']);


### PR DESCRIPTION
* Add some checks before even trying to remove files that may not be loaded anyway.
* Simply add the jquery ui css rather than overriding a non-existent path.
* Note that the iasc_admin theme does the jquery ui css differently, so *maybe* the iasc theme should do it the same way. I dunno.
* script.js was getting replaced with itself, which seems inefficient.