### PR TITLE
[master] IASC-502: Updating OpenAtrium core to 2.87

### DIFF
--- a/src/make/includes/drupal-org-core.make
+++ b/src/make/includes/drupal-org-core.make
@@ -7,7 +7,7 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.54
+projects[drupal][version] = 7.56
 
 ; ***** Patches from Panopoly *******
 ; Bug with image styles on database update

--- a/src/make/includes/openatrium.make
+++ b/src/make/includes/openatrium.make
@@ -9,7 +9,7 @@ core = 7.x
 ; ******************** RELEASE *******************
 
 projects[oa_core][subdir] = contrib
-projects[oa_core][version] = 2.86
+projects[oa_core][version] = 2.87
 
 ; ************************************************
 ; ************* Open Atrium Builtin Apps *********
@@ -73,7 +73,7 @@ projects[oa_events_import][version] = 2.27
 projects[oa_favorites][version] = 2.5
 projects[oa_favorites][subdir] = apps
 
-projects[oa_files][version] = 2.20
+projects[oa_files][version] = 2.21
 projects[oa_files][subdir] = apps
 
 projects[oa_home][version] = 2.5
@@ -100,7 +100,7 @@ projects[oa_notifications][version] = 2.34
 projects[oa_project][version] = 2.2
 projects[oa_project][subdir] = apps
 
-projects[oa_related][version] = 2.12
+projects[oa_related][version] = 2.13
 projects[oa_related][subdir] = apps
 
 projects[oa_sandbox][version] = 2.2
@@ -161,45 +161,45 @@ projects[oa_radix][version] = 3.25
 ; so we can patch or update certain projects fetched by Panopoly's makefiles.
 ; NOTE: If you are running Drush 6, this section should be placed at the TOP
 
-projects[panopoly_core][version] = 1.46
+projects[panopoly_core][version] = 1.47
 projects[panopoly_core][subdir] = panopoly
-projects[panopoly_core][patch][2477347] = https://www.drupal.org/files/issues/2477347-panopoly_core-views-4.patch
+projects[panopoly_core][patch][2477347] = https://www.drupal.org/files/issues/2477347-panopoly_core-views-7.patch
 projects[panopoly_core][patch][2477363] = https://www.drupal.org/files/issues/2477363-panopoly_core-ctools-21.patch
 projects[panopoly_core][patch][2477369] = https://www.drupal.org/files/issues/2477369-panopoly_core-entity-6.patch
-projects[panopoly_core][patch][2477375] = https://www.drupal.org/files/issues/2477375-panopoly_core-entityreference-1.patch
+projects[panopoly_core][patch][2477375] = https://www.drupal.org/files/issues/2477375-panopoly_core-entityreference-9.patch
 projects[panopoly_core][patch][2477379] = https://www.drupal.org/files/issues/2477379-panopoly_core-token-1.patch
 projects[panopoly_core][patch][2592821] = https://www.drupal.org/files/issues/2592821-panopoly_core-apps-3.patch
 
-projects[panopoly_images][version] = 1.46
+projects[panopoly_images][version] = 1.47
 projects[panopoly_images][subdir] = panopoly
 projects[panopoly_images][patch][2521968] = https://www.drupal.org/files/issues/panopoly_images-manualcrop_is_showing_for_videos-2521968-1.patch
 
-projects[panopoly_theme][version] = 1.45
+projects[panopoly_theme][version] = 1.47
 projects[panopoly_theme][subdir] = panopoly
 projects[panopoly_theme][patch][2656920] = https://www.drupal.org/files/issues/2656920-panopoly-theme-radix-layouts-4.patch
 
-projects[panopoly_magic][version] = 1.46
+projects[panopoly_magic][version] = 1.47
 projects[panopoly_magic][subdir] = panopoly
 projects[panopoly_magic][patch][2611876] = https://www.drupal.org/files/issues/panopoly_magic-add_descriptions_to-2611876-2.patch
 
-projects[panopoly_widgets][version] = 1.46
+projects[panopoly_widgets][version] = 1.47
 projects[panopoly_widgets][subdir] = panopoly
 projects[panopoly_widgets][patch][2473495] = https://www.drupal.org/files/issues/2473495-panopoly_widgets-media-20.patch
 projects[panopoly_widgets][patch][2477397] = https://www.drupal.org/files/issues/2477397-panopoly_widgets-file_entity-2.patch
 
-projects[panopoly_admin][version] = 1.46
+projects[panopoly_admin][version] = 1.47
 projects[panopoly_admin][subdir] = panopoly
 
-projects[panopoly_users][version] = 1.46
+projects[panopoly_users][version] = 1.47
 projects[panopoly_users][subdir] = panopoly
 
-projects[panopoly_pages][version] = 1.46
+projects[panopoly_pages][version] = 1.47
 projects[panopoly_pages][subdir] = panopoly
 
-projects[panopoly_wysiwyg][version] = 1.46
+projects[panopoly_wysiwyg][version] = 1.47
 projects[panopoly_wysiwyg][subdir] = panopoly
 
-projects[panopoly_search][version] = 1.46
+projects[panopoly_search][version] = 1.47
 projects[panopoly_search][subdir] = panopoly
 
 ; ***************** End Panopoly *****************

--- a/src/make/includes/openatrium.make
+++ b/src/make/includes/openatrium.make
@@ -9,7 +9,7 @@ core = 7.x
 ; ******************** RELEASE *******************
 
 projects[oa_core][subdir] = contrib
-projects[oa_core][version] = 2.85
+projects[oa_core][version] = 2.86
 
 ; ************************************************
 ; ************* Open Atrium Builtin Apps *********
@@ -73,7 +73,7 @@ projects[oa_events_import][version] = 2.27
 projects[oa_favorites][version] = 2.5
 projects[oa_favorites][subdir] = apps
 
-projects[oa_files][version] = 2.19
+projects[oa_files][version] = 2.20
 projects[oa_files][subdir] = apps
 
 projects[oa_home][version] = 2.5
@@ -130,7 +130,7 @@ projects[oa_tour][subdir] = apps
 projects[oa_tour_defaults][version] = 2.3
 projects[oa_tour_defaults][subdir] = apps
 
-projects[oa_wizard][version] = 2.2
+projects[oa_wizard][version] = 2.3
 projects[oa_wizard][subdir] = apps
 
 ; ***************** End Apps *********************
@@ -161,16 +161,16 @@ projects[oa_radix][version] = 3.25
 ; so we can patch or update certain projects fetched by Panopoly's makefiles.
 ; NOTE: If you are running Drush 6, this section should be placed at the TOP
 
-projects[panopoly_core][version] = 1.45
+projects[panopoly_core][version] = 1.46
 projects[panopoly_core][subdir] = panopoly
 projects[panopoly_core][patch][2477347] = https://www.drupal.org/files/issues/2477347-panopoly_core-views-4.patch
 projects[panopoly_core][patch][2477363] = https://www.drupal.org/files/issues/2477363-panopoly_core-ctools-21.patch
-projects[panopoly_core][patch][2477369] = https://www.drupal.org/files/issues/2477369-panopoly_core-entity-5.patch
+projects[panopoly_core][patch][2477369] = https://www.drupal.org/files/issues/2477369-panopoly_core-entity-6.patch
 projects[panopoly_core][patch][2477375] = https://www.drupal.org/files/issues/2477375-panopoly_core-entityreference-1.patch
 projects[panopoly_core][patch][2477379] = https://www.drupal.org/files/issues/2477379-panopoly_core-token-1.patch
 projects[panopoly_core][patch][2592821] = https://www.drupal.org/files/issues/2592821-panopoly_core-apps-3.patch
 
-projects[panopoly_images][version] = 1.45
+projects[panopoly_images][version] = 1.46
 projects[panopoly_images][subdir] = panopoly
 projects[panopoly_images][patch][2521968] = https://www.drupal.org/files/issues/panopoly_images-manualcrop_is_showing_for_videos-2521968-1.patch
 
@@ -178,28 +178,28 @@ projects[panopoly_theme][version] = 1.45
 projects[panopoly_theme][subdir] = panopoly
 projects[panopoly_theme][patch][2656920] = https://www.drupal.org/files/issues/2656920-panopoly-theme-radix-layouts-4.patch
 
-projects[panopoly_magic][version] = 1.45
+projects[panopoly_magic][version] = 1.46
 projects[panopoly_magic][subdir] = panopoly
 projects[panopoly_magic][patch][2611876] = https://www.drupal.org/files/issues/panopoly_magic-add_descriptions_to-2611876-2.patch
 
-projects[panopoly_widgets][version] = 1.45
+projects[panopoly_widgets][version] = 1.46
 projects[panopoly_widgets][subdir] = panopoly
 projects[panopoly_widgets][patch][2473495] = https://www.drupal.org/files/issues/2473495-panopoly_widgets-media-20.patch
 projects[panopoly_widgets][patch][2477397] = https://www.drupal.org/files/issues/2477397-panopoly_widgets-file_entity-2.patch
 
-projects[panopoly_admin][version] = 1.45
+projects[panopoly_admin][version] = 1.46
 projects[panopoly_admin][subdir] = panopoly
 
-projects[panopoly_users][version] = 1.45
+projects[panopoly_users][version] = 1.46
 projects[panopoly_users][subdir] = panopoly
 
-projects[panopoly_pages][version] = 1.45
+projects[panopoly_pages][version] = 1.46
 projects[panopoly_pages][subdir] = panopoly
 
-projects[panopoly_wysiwyg][version] = 1.45
+projects[panopoly_wysiwyg][version] = 1.46
 projects[panopoly_wysiwyg][subdir] = panopoly
 
-projects[panopoly_search][version] = 1.45
+projects[panopoly_search][version] = 1.46
 projects[panopoly_search][subdir] = panopoly
 
 ; ***************** End Panopoly *****************


### PR DESCRIPTION
Merges `develop` into `master`, which includes #13 and #14.
